### PR TITLE
Feature/aliases

### DIFF
--- a/src/commands/jira/askForTicket.ts
+++ b/src/commands/jira/askForTicket.ts
@@ -53,7 +53,10 @@ const askForTicketSelection = async (): Promise<Ticket> => {
   ]);
   const [index] = ticketNumber.split(" ");
   const ticket = await getTicketInfo(index);
-  copyTicketToClipboard({ ticket });
+
+  if (ticket != null) {
+    copyTicketToClipboard({ ticket });
+  }
   return ticket;
 };
 

--- a/src/commands/jira/askToCreateNewTicket.ts
+++ b/src/commands/jira/askToCreateNewTicket.ts
@@ -7,7 +7,7 @@ import { getHistory } from "./getHistory";
 
 export const askToCreateNewTicket = async (): Promise<Ticket> => {
   let result: Ticket;
-  const { url, description } = await inquirer.prompt([
+  const { url, description, aliases: aliasesString } = await inquirer.prompt([
     {
       type: "text",
       name: "url",
@@ -28,16 +28,22 @@ export const askToCreateNewTicket = async (): Promise<Ticket> => {
       type: "text",
       name: "description",
       message: "Add a description:"
+    },
+    {
+      type: "text",
+      name: "aliases",
+      message: "Add comma-separated aliases for easy searching."
     }
   ]);
+
+  const aliases = aliasesString.split(",").map(str => str.trim());
   const [base, number] = url.split("browse/");
   result = {
     base: base + "browse/",
     url,
     number,
     description,
-    //TODO add aliases
-    aliases: []
+    aliases
   };
   log(result);
   const { isConfirmed } = await inquirer.prompt({

--- a/src/commands/jira/askToCreateNewTicket.ts
+++ b/src/commands/jira/askToCreateNewTicket.ts
@@ -35,7 +35,9 @@ export const askToCreateNewTicket = async (): Promise<Ticket> => {
     base: base + "browse/",
     url,
     number,
-    description
+    description,
+    //TODO add aliases
+    aliases: []
   };
   log(result);
   const { isConfirmed } = await inquirer.prompt({

--- a/src/commands/jira/index.ts
+++ b/src/commands/jira/index.ts
@@ -50,7 +50,7 @@ const action = async (query: string, command: any) => {
   let ticket = await askForTicket();
 
   if (typeof ticket === "undefined") {
-    ticket = await askToCreateNewTicket();
+    await askToCreateNewTicket();
   }
 };
 

--- a/src/commands/jira/index.ts
+++ b/src/commands/jira/index.ts
@@ -6,17 +6,11 @@ import { askToCreateNewTicket } from "./askToCreateNewTicket";
 import log from "../../common/log";
 import clipboardy from "clipboardy";
 
-export const isValidTicketNumber = async (
-  ticketNumber: TicketNumber
-): Promise<boolean> => {
-  if (ticketNumber === "") return false;
+const getTicketByQuery = async (val: string): Promise<Ticket|null> => {
+  const ticket: [string, Ticket] = Object.entries(await getHistory())
+    .find(([ticketNumber, ticket]) => ticketNumber === val || ticket.aliases.includes(val));
 
-  const validKeys = await getTicketNumbers();
-  return validKeys.includes(ticketNumber);
-};
-
-export const getTicketNumbers = async () => {
-  return Object.keys(await getHistory());
+  return ticket != null ? ticket[1] : null;
 };
 
 export const getTicketInfo = async (
@@ -38,11 +32,19 @@ export const copyTicketToClipboard = async ({
   log(`Copied ${ticket.url} to clipboard.`, "success");
 };
 
-const action = async (ticketNumber: string, command: any) => {
+const action = async (query: string, command: any) => {
   inquirer.registerPrompt("command", command);
   inquirer.registerPrompt("autocomplete", autocomplete);
-  if (await isValidTicketNumber(ticketNumber)) {
-    return await copyTicketToClipboard({ ticketNumber });
+
+  if (query != "" && query != null) {
+    const ticket = await getTicketByQuery(query);
+
+    if (ticket != null) {
+      return await copyTicketToClipboard({
+        ticket,
+        ticketNumber: ticket.number
+      });
+    }
   }
 
   let ticket = await askForTicket();

--- a/src/commands/jira/index.ts
+++ b/src/commands/jira/index.ts
@@ -6,6 +6,13 @@ import { askToCreateNewTicket } from "./askToCreateNewTicket";
 import log from "../../common/log";
 import clipboardy from "clipboardy";
 
+export const getTicketByAlias = async (val: string): Promise<Ticket|null> => {
+  const ticket: Ticket = Object.values(await getHistory())
+    .find((indvTicket) => indvTicket.aliases.includes(val));
+
+  return ticket != null ? ticket : null;
+};
+
 const getTicketByQuery = async (val: string): Promise<Ticket|null> => {
   const ticket: [string, Ticket] = Object.entries(await getHistory())
     .find(([ticketNumber, ticket]) => ticketNumber === val || ticket.aliases.includes(val));

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,7 @@ interface Ticket {
   base: TicketBase;
   url: TicketUrl; // url = base + number
   description?: TicketDescription;
+  aliases: Array<String>;
 }
 
 interface TicketCollection {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,7 +8,7 @@ interface Ticket {
   base: TicketBase;
   url: TicketUrl; // url = base + number
   description?: TicketDescription;
-  aliases: Array<String>;
+  aliases: Array<string>;
 }
 
 interface TicketCollection {


### PR DESCRIPTION
Adds the ability to specify aliases for tickets during creation.

Aliases must be unique - you cannot currently reuse an alias.

Resolves https://github.com/theosyslack/leo/issues/3.

Also resolves a bug where an error would be shown when filling in a new ticket's URL.